### PR TITLE
Fix 404 by adding static index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # CODEX
+
+This repository contains a simple static site that can be deployed on Vercel.
+
+## Deploying on Vercel
+
+Just deploy this repository to Vercel. The `index.html` file at the root will be served as the homepage.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CODEX</title>
+</head>
+<body>
+    <h1>Hello from CODEX</h1>
+    <p>If you see this page, the deployment was successful.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple `index.html` so Vercel has content to serve
- document deploying the static site in the README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840039bf6c88324ab448097256e895a